### PR TITLE
Remove references to heroes

### DIFF
--- a/2019-01/PITCHME.md
+++ b/2019-01/PITCHME.md
@@ -42,7 +42,7 @@ Note:
 @snapend
 
 @snap[midpoint]
-#### Why would I want to be an OpenStack Hero?
+#### Why would I want to contribute upstream?
 @snapend
 
 Note:
@@ -101,7 +101,7 @@ Note:
 @title[Where to help]
 
 @snap[north-west]
-Heroes wanted...
+Contributors wanted...
 @snapend
 
 @snap[west list-content-verbose span-100]


### PR DESCRIPTION
Remove text about OpenStack heroes. It does not take a hero to
contribute and framing it that way is intimidating.

-----
[View rendered 2019-01/PITCHME.md](https://github.com/cmurphy/presentations/blob/master/2019-01/PITCHME.md)